### PR TITLE
Improve Chrome start reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ Dieses Projekt automatisiert das Erstellen von Anzeigen bei Kleinanzeigen (ehema
 ```bash
 python main.py
 ```
-Das Skript startet Chrome automatisch im Debug-Modus (Port 9222). Stelle sicher,
- dass Chrome unter `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome` verfügbar ist.
+Das Skript startet Chrome automatisch im Debug-Modus (Port 9222).
+Falls Chrome an einem anderen Speicherort installiert ist, kann der Pfad in
+`main.py` über die Konstante `CHROME_PATH` angepasst werden.
 
 ## Log-Analyse
 Nach dem Ausführen werden Einträge in `upload_log.csv` gespeichert. Mit

--- a/main.py
+++ b/main.py
@@ -180,9 +180,20 @@ def starte_chrome_debugging():
         "--start-maximized",
     ]
 
-    subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-    time.sleep(2)
-    return prüfe_chrome_debug_session()
+    try:
+        subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except FileNotFoundError:
+        print(f"[red]❌ Chrome nicht gefunden unter {CHROME_PATH}[/red]")
+        return False
+
+    # Warte, bis die Debug-Schnittstelle erreichbar ist (max. 10s)
+    for _ in range(10):
+        if prüfe_chrome_debug_session():
+            return True
+        time.sleep(1)
+
+    print("[red]⚠️ Chrome-Debugging konnte nicht gestartet werden.[/red]")
+    return False
 
 def lade_bilder(driver, bilderpfad):
     bilddateien = [


### PR DESCRIPTION
## Summary
- robust Chrome startup in `starte_chrome_debugging`
- clarify how to change the Chrome path in README

## Testing
- `python -m py_compile main.py analyze_logs.py`


------
https://chatgpt.com/codex/tasks/task_b_685d6b60ccb4832890df511cfca2cd7c